### PR TITLE
Added `TelemetryAsync` for use in async python

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install telemetry-sh
 First, you need to initialize the SDK with your API key.
 
 ```python
-from telemetry import Telemetry
+from telemetry_sh import Telemetry
 
 telemetry = Telemetry()
 telemetry.init("your_api_key")

--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ response = telemetry.query(query)
 print(response)
 ```
 
+### Async usage
+
+If your codebase uses asyncio/async python, you can use `TelemetryAsync`:
+
+```python
+from telemetry import TelemetryAsync as Telemetry
+
+telemetry = Telemetry()
+telemetry.init("your_api_key")
+```
+
+The async SDK has the same structure as the sync one:
+```python
+data = {
+    "field1": "value1",
+    "field2": "value2"
+}
+response = await telemetry.log("your_table_name", data)
+print(response)
+```
+
+Similarly for query:
+```python
+query = "SELECT * FROM your_table_name WHERE field1 = 'value1'"
+response = await telemetry.query(query)
+print(response)
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     url="https://github.com/telemetry-sh/telemetry-python",
     packages=find_packages(),
     install_requires=[
-        "requests"
+        "requests",
+        "aiohttp"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/telemetry_sh/__init__.py
+++ b/telemetry_sh/__init__.py
@@ -1,3 +1,4 @@
 from .telemetry import Telemetry
+from .telemetry_async import TelemetryAsync
 
 __all__ = ["Telemetry"]

--- a/telemetry_sh/telemetry.py
+++ b/telemetry_sh/telemetry.py
@@ -1,5 +1,6 @@
 import requests
 import json
+from typing import Union, List
 
 class Telemetry:
     def __init__(self):
@@ -9,7 +10,7 @@ class Telemetry:
     def init(self, api_key: str):
         self.api_key = api_key
 
-    def log(self, table: str, data: dict) -> dict:
+    def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
         if not self.api_key:
             raise ValueError("API key is not initialized. Please call init() with your API key.")
         

--- a/telemetry_sh/telemetry_async.py
+++ b/telemetry_sh/telemetry_async.py
@@ -1,0 +1,46 @@
+import aiohttp
+import json
+from typing import Union, List
+
+
+class TelemetryAsync:
+    def __init__(self):
+        self.api_key = None
+        self.base_url = "https://api.telemetry.sh"
+
+    def init(self, api_key: str):
+        self.api_key = api_key
+
+    async def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
+        if not self.api_key:
+            raise ValueError(
+                "API key is not initialized. Please call init() with your API key."
+            )
+
+        headers = {"Content-Type": "application/json", "Authorization": self.api_key}
+
+        body = {"data": data, "table": table}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.base_url}/log", headers=headers, json=body
+            ) as response:
+                response = await response.text()
+                return json.loads(response)
+
+    async def query(self, query: str) -> dict:
+        if not self.api_key:
+            raise ValueError(
+                "API key is not initialized. Please call init() with your API key."
+            )
+
+        headers = {"Content-Type": "application/json", "Authorization": self.api_key}
+
+        body = {"query": query, "realtime": True, "json": True}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.base_url}/query", headers=headers, json=body
+            ) as response:
+                response = await response.text()
+                return json.loads(response)


### PR DESCRIPTION
In codebases uses asyncio, using `requests` to log will block all ongoing asyncio tasks till the request completes. I added `TelemetryAsync` which uses `aiohttp` internally, updated the readme to have async examples.

Also fixed readme bug:
```python
from telemetry import Telemetry
```
to:
```python
from telemetry_sh import Telemetry
```

And added better typing:
```python
def log(self, table: str, data: dict) -> dict:
```
to:
```python
def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
```

Since telemetry supports bulk ingestion.
