### PR TITLE
if response from server is error, don't fail silently

### DIFF
--- a/telemetry_sh/telemetry.py
+++ b/telemetry_sh/telemetry.py
@@ -9,6 +9,12 @@ class Telemetry:
 
     def init(self, api_key: str):
         self.api_key = api_key
+        
+    def check_and_return(self, response: requests.Response) -> dict:
+        response_json = response.json()
+        if response_json.get("status", "error") == "error":
+            raise Exception(response_json.get("message", "Unknown error"))
+        return response_json
 
     def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
         if not self.api_key:
@@ -25,7 +31,7 @@ class Telemetry:
         }
         
         response = requests.post(f"{self.base_url}/log", headers=headers, data=json.dumps(body))
-        return response.json()
+        return self.check_and_return(response)
 
     def query(self, query: str) -> dict:
         if not self.api_key:
@@ -43,6 +49,6 @@ class Telemetry:
         }
         
         response = requests.post(f"{self.base_url}/query", headers=headers, data=json.dumps(body))
-        return response.json()
+        return self.check_and_return(response)
 
 telemetry = Telemetry()

--- a/telemetry_sh/telemetry_async.py
+++ b/telemetry_sh/telemetry_async.py
@@ -9,6 +9,12 @@ class TelemetryAsync:
 
     def init(self, api_key: str):
         self.api_key = api_key
+        
+    async def check_and_return(self, response: aiohttp.ClientResponse) -> dict:
+        respose_json = await response.json()
+        if respose_json.get("status", "error") == "error":
+            raise Exception(respose_json.get("message", "Unknown error"))
+        return respose_json
 
     async def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
         if not self.api_key:
@@ -24,7 +30,7 @@ class TelemetryAsync:
             async with session.post(
                 f"{self.base_url}/log", headers=headers, json=body
             ) as response:
-                return await response.json()
+                return await self.check_and_return(response)
 
     async def query(self, query: str) -> dict:
         if not self.api_key:
@@ -40,4 +46,4 @@ class TelemetryAsync:
             async with session.post(
                 f"{self.base_url}/query", headers=headers, json=body
             ) as response:
-                return await response.json()
+                return await self.check_and_return(response)


### PR DESCRIPTION
Right now if the server returns an error, the SDK fails silently, you have to manually check:

```python
data = {"test": "test", "timestamp": datetime.now(timezone.utc).isoformat()}
response = await telemetry.log("test", data)
if response['status'] == 'error':
    # failed, do something
```

now, the SDK will throw an error, with the `response['message']` if the server returns an error.

```python
data = {"test": "test", "timestamp": datetime.now(timezone.utc).isoformat()}
try:
   await telemetry.log("test", data)
except Exception as e:
   # failed, do something
```


Updated for both async and sync. Now JS and python SDK have same behaviour: https://github.com/telemetry-sh/telemetry/pull/1
