### PR TITLE
add typing hints for telemetry-python

### DIFF
--- a/telemetry_sh/telemetry.py
+++ b/telemetry_sh/telemetry.py
@@ -1,6 +1,7 @@
 import requests
 import json
 from typing import Union, List
+from telemetry_sh.telemetry_types import TelemetryQueryResponse, TelemetryLogResponse, TelemetryQueryType
 
 class Telemetry:
     def __init__(self):
@@ -16,7 +17,7 @@ class Telemetry:
             raise Exception(response_json.get("message", "Unknown error"))
         return response_json
 
-    def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
+    def log(self, table: str, data: Union[dict, List[dict]]) -> TelemetryLogResponse:
         if not self.api_key:
             raise ValueError("API key is not initialized. Please call init() with your API key.")
         
@@ -33,7 +34,7 @@ class Telemetry:
         response = requests.post(f"{self.base_url}/log", headers=headers, data=json.dumps(body))
         return self.check_and_return(response)
 
-    def query(self, query: str) -> dict:
+    def query(self, query: str) -> TelemetryQueryResponse[TelemetryQueryType]:
         if not self.api_key:
             raise ValueError("API key is not initialized. Please call init() with your API key.")
         

--- a/telemetry_sh/telemetry_async.py
+++ b/telemetry_sh/telemetry_async.py
@@ -1,5 +1,6 @@
 import aiohttp
 from typing import Union, List
+from telemetry_sh.telemetry_types import TelemetryQueryResponse, TelemetryQueryType, TelemetryLogResponse
 
 
 class TelemetryAsync:
@@ -16,7 +17,7 @@ class TelemetryAsync:
             raise Exception(respose_json.get("message", "Unknown error"))
         return respose_json
 
-    async def log(self, table: str, data: Union[dict, List[dict]]) -> dict:
+    async def log(self, table: str, data: Union[dict, List[dict]]) -> TelemetryLogResponse:
         if not self.api_key:
             raise ValueError(
                 "API key is not initialized. Please call init() with your API key."
@@ -32,7 +33,7 @@ class TelemetryAsync:
             ) as response:
                 return await self.check_and_return(response)
 
-    async def query(self, query: str) -> dict:
+    async def query(self, query: str) -> TelemetryQueryResponse[TelemetryQueryType]:
         if not self.api_key:
             raise ValueError(
                 "API key is not initialized. Please call init() with your API key."

--- a/telemetry_sh/telemetry_types.py
+++ b/telemetry_sh/telemetry_types.py
@@ -1,0 +1,12 @@
+from typing import Mapping, TypedDict, Literal, TypeVar, Generic
+TelemetryQueryType = TypeVar("TelemetryQueryType", bound=Mapping)
+
+class TelemetryQueryResponse(TypedDict, Generic[TelemetryQueryType]):
+    data: list[TelemetryQueryType]
+    status: Literal["success"]
+    key_order: list[str]
+
+class TelemetryLogResponse(TypedDict):
+    status: Literal["success"]
+    message: str
+


### PR DESCRIPTION
This pull request adds typing hints to telemetry-python. Same PR for JS client: https://github.com/telemetry-sh/telemetry/pull/1

```python
from typing import Mapping, TypedDict, Literal, TypeVar, Generic
TelemetryQueryType = TypeVar("TelemetryQueryType", bound=Mapping)

class TelemetryQueryResponse(TypedDict, Generic[TelemetryQueryType]):
    data: list[TelemetryQueryType]
    status: Literal["success"]
    key_order: list[str]

class TelemetryLogResponse(TypedDict):
    status: Literal["success"]
    message: str
```

So now you can use `TypeDict` and get typing hints for queries:

```python
from telemetry_sh.telemetry_types import TelemetryQueryResponse

class UberData(TypedDict):
    city: str
    price: float

response: TelemetryQueryResponse[UberData] = await telemetry.query("SELECT city, price from uber_rides");
uber_data = response["data"]
uber_data # is of type UberData.
```